### PR TITLE
Extends DB cleaning logic

### DIFF
--- a/lib/waterpig/database-cleaner.rb
+++ b/lib/waterpig/database-cleaner.rb
@@ -4,7 +4,9 @@ RSpec.configure do |config|
   #config.use_transactional_fixtures = false
   DatabaseCleaner.strategy = :transaction
 
+  config.add_setting :waterpig_exclude_cleaning_key, :default => :manual_database_cleaning
   config.add_setting :waterpig_truncation_types, :default => [:feature]
+  config.add_setting :waterpig_skip_cleaning_types, :default => []
   config.add_setting :waterpig_exclude_seeds_types, :default => []
   config.add_setting :waterpig_database_truncation_config, :default => {:except => %w[spatial_ref_sys]}
   config.add_setting :waterpig_db_seeds, :default => 'db/seeds.rb'
@@ -23,7 +25,21 @@ RSpec.configure do |config|
     end
   end
 
-  config.before :all, :type => proc{ |value| config.waterpig_truncation_types.include?(value)} do
+  def use_truncate?(config, metadata)
+    return false if metadata[config.waterpig_exclude_cleaning_key]
+    return false if config.waterpig_skip_cleaning_types.include?(metadata[:type])
+    return false unless config.waterpig_truncation_types.include?(metadata[:type])
+    return true
+  end
+
+  def use_transaction?(config, metadata)
+    return false if metadata[config.waterpig_exclude_cleaning_key]
+    return false if use_truncate?(config, metadata)
+    return false if config.waterpig_skip_cleaning_types.include?(metadata[:type])
+    return true
+  end
+
+  config.before :all, :description => proc{ |value, metadata| use_truncate?(config, metadata) } do
     with_showing(true, false) do
       DatabaseCleaner.clean_with :truncation, config.waterpig_database_truncation_config
       unless config.waterpig_exclude_seeds_types.include?(self.class.metadata[:type])
@@ -34,7 +50,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.after :all, :type => proc{ |value| config.waterpig_truncation_types.include?(value)} do
+  config.after :all, :description => proc{ |value, metadata| use_truncate?(config, metadata) } do
     with_showing(true, true) do
       Rails.application.config.action_dispatch.show_detailed_exceptions = true
       DatabaseCleaner.clean_with :truncation, config.waterpig_database_truncation_config
@@ -44,11 +60,11 @@ RSpec.configure do |config|
     end
   end
 
-  config.before :each, :type => proc{ |value| !config.waterpig_truncation_types.include?(value) } do
+  config.before :each, :description => proc{ |value, metadata| use_transaction?(config, metadata) } do
     DatabaseCleaner.start
   end
 
-  config.after :each, :type => proc{ |value| !config.waterpig_truncation_types.include?(value) } do
+  config.after :each, :description => proc{ |value, metadata| use_transaction?(config, metadata) } do
     DatabaseCleaner.clean
   end
 


### PR DESCRIPTION
Allows for uncleaned types and individual groups.
Configs are

:waterpig_exclude_cleaning_key(default "manual_database_cleaning") -
  example/group metadata to skip cleaning
:waterpig_skip_cleaning_types(default []) -
  example group types not to clean
:waterpig_exclude_seeds_types(default []) -
  example/group types not to load seeds to

Additionally, the "should I clean?" logic has been extracted to make it
easier to add behaviors like this - e.g. if we needed a "no seeds"
metadata in addition to a type...
