### PR TITLE
Absorbing utilities built elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of helpers for Capybara, collected over several years by Logical Re
 Selecting A Browser Driver
 --------------------------
 
-You can JS and non-JS capybara drivers with either environment variables or your rspec config.  The
+You can set JS and non-JS capybara drivers with either environment variables or your rspec config.  The
 two currently supported drivers are poltergeist_debug (Poltergeist with remote debugging enabled) 
 and selenium_chrome.  If none is specified, waterpig will try to configure poltergeist_debug by default.
 
@@ -35,10 +35,84 @@ Or set the rspec config waterpig_autosnap? to true in your config.
 
 Screenshots will be emitted into tmp/, with a subdirectory named for each spec and a numbered file for each step.
 To change the screenshot destination, set waterpig_
- 
-    
    
 Browser Console Logging
 -----------------------
 
-The Waterpig::BrowserConsoleLogger class can execute a remote call to console.history() in your browser at the end of  
+The Waterpig::BrowserConsoleLogger class can execute a remote call to console.history() in your browser to retrieve   
+the contents of the browser console, and log it to file.  This is extremely useful for debugging front-end issues
+during integration specs.  
+
+For browser console logging to work, the console.history() method must have already been defined in your browser.  
+This must be handled separately, see the console history injector in Xing for an example.
+
+To turn on browser console logging:
+
+
+At the command line:
+    LOG_BROWSER_CONSOLE=true rspec spec/features/my_cool_spec.rb
+
+In your rspec config
+    RSpec.configure do |config|
+      config.waterpig_log_browser_console = true
+    end
+
+
+Blocking Spec Cleanup For Browser Requests
+------------------------------------------
+
+Much suffering is caused when rspec and Capybara clean up after a spec while a request is still being
+processed. Typically, the database fixtures are reset by DatabaseCleaner because rspec thinks the example
+is complete, but then something fails in Rails when an expected database record is absent.  This can cause
+mysterious intermittant, timing-related failures in specs.
+
+To fix this, install Waterpig::RackRequestWait as a middleware and configure your end-to-end tests to block 
+on Waterpig::RackRequestWait.wait_for_idle(), as follows:
+
+In config/environments/test.rb
+    Rails.application.configure do
+      config.middleware.unshift Waterpig::RackRequestWait
+    end
+
+In your rspec config, wrap your database cleanup command in a call to wait_for_idle().  Assuming all your
+end-to-end tests have the metadata :type => :feature, you could:
+
+    RSpec.configure do |config|
+
+      config.before(:all, :type => :feature) do
+        Waterpig::RackRequestWait.wait_for_idle do 
+          DatabaseCleaner.clean(:truncation)
+        end
+      end
+   
+
+Rebuilding the Test Database from a Template
+--------------------------------------------
+
+If you are using DatabaseCleaner or other truncation method, cleaning your database between tests can be slow,
+particularly if your database has a lot of setup in seeds.rb.  Waterpig's solution is to use a second, test
+template database, that contains a cleaned and seeded database, and to leverage PostgreSQL's database
+template feature to re-initialize the test database from that template.
+
+In your database.yml, configure the test database with a template: setting, and  an additional template DB.
+
+    test:
+      adapter: postgresql
+      database: my_app_test
+      template: my_app_test_template
+
+    test_template:
+      adapter: postgresql
+      database: my_app_test_template
+
+Create the template database at the command line the same as any other Rails DB, treat "test_template" as a 
+Rails environment for this purpose:
+
+    > RAILS_ENV=test_template bundle exec rake db:create
+
+NOTE:  the test template maintainer code can detect new migrations, but cannot detect changes to db/seeds.rb. If
+you have changed your seeds file without adding a new migration, your test template will not have the new seeds 
+until you drop and rebuild it.  You can do that with:
+
+
+    > RAILS_ENV=test_template bundle exec rake db:drop db:create

--- a/README.md
+++ b/README.md
@@ -1,4 +1,44 @@
-waterpig
+Waterpig
 ========
 
-Helpers to make capybara just that much nicer
+A collection of helpers for Capybara, collected over several years by Logical Reality Design.
+
+Selecting A Browser Driver
+--------------------------
+
+You can JS and non-JS capybara drivers with either environment variables or your rspec config.  The
+two currently supported drivers are poltergeist_debug (Poltergeist with remote debugging enabled) 
+and selenium_chrome.  If none is specified, waterpig will try to configure poltergeist_debug by default.
+
+Mostly one cares about drivers when :js => true in capybara specs, in which case capybara_js_driver is
+the setting you care about.
+
+At the command line:
+    CAPYBARA_JS_DRIVER=poltergeist_debug rspec spec/features/my_cool_spec.rb
+    CAPYBARA_JS_DRIVER=selenium_chrome rspec spec/features/my_cool_spec.rb
+
+In your rspec config
+    RSpec.configure do |config|
+      config.capybara_js_driver = :selenium_chrome
+    end
+
+Browser Snapshotting
+--------------------
+
+If you are also using the rspec-steps gem and poltergeist, Waterpig's Autosnap feature can generate screenshots 
+of the browser at the beginning of each step, to give you intelligence on the test in the middle of a user story.  
+To use it simply set the environment variable WATERPIG_AUTOSNAP, for example:
+
+    WATERPIG_AUTOSNAP=true rspec spec/features/my_cool_spec.rb
+
+Or set the rspec config waterpig_autosnap? to true in your config.
+
+Screenshots will be emitted into tmp/, with a subdirectory named for each spec and a numbered file for each step.
+To change the screenshot destination, set waterpig_
+ 
+    
+   
+Browser Console Logging
+-----------------------
+
+The Waterpig::BrowserConsoleLogger class can execute a remote call to console.history() in your browser at the end of  

--- a/README.md
+++ b/README.md
@@ -7,87 +7,106 @@ Selecting A Browser Driver
 --------------------------
 
 You can set JS and non-JS capybara drivers with either environment variables or your rspec config.  The
-two currently supported drivers are poltergeist_debug (Poltergeist with remote debugging enabled) 
+two currently supported drivers are poltergeist_debug (Poltergeist with remote debugging enabled)
 and selenium_chrome.  If none is specified, waterpig will try to configure poltergeist_debug by default.
 
-Mostly one cares about drivers when :js => true in capybara specs, in which case capybara_js_driver is
-the setting you care about.
+Mostly one cares about drivers when `:js => true` in capybara specs, in which
+case `capybara_js_driver` is the setting you care about.
 
 At the command line:
-    CAPYBARA_JS_DRIVER=poltergeist_debug rspec spec/features/my_cool_spec.rb
-    CAPYBARA_JS_DRIVER=selenium_chrome rspec spec/features/my_cool_spec.rb
+```
+CAPYBARA_JS_DRIVER=poltergeist_debug rspec spec/features/my_cool_spec.rb
+CAPYBARA_JS_DRIVER=selenium_chrome rspec spec/features/my_cool_spec.rb
+```
 
 In your rspec config
-    RSpec.configure do |config|
-      config.capybara_js_driver = :selenium_chrome
-    end
+
+```ruby
+RSpec.configure do |config|
+  config.capybara_js_driver = :selenium_chrome
+end
+```
 
 Browser Snapshotting
 --------------------
 
-If you are also using the rspec-steps gem and poltergeist, Waterpig's Autosnap feature can generate screenshots 
-of the browser at the beginning of each step, to give you intelligence on the test in the middle of a user story.  
+If you are also using the rspec-steps gem and poltergeist, Waterpig's Autosnap feature can generate screenshots
+of the browser at the beginning of each step, to give you intelligence on the test in the middle of a user story.
 To use it simply set the environment variable WATERPIG_AUTOSNAP, for example:
 
-    WATERPIG_AUTOSNAP=true rspec spec/features/my_cool_spec.rb
+```
+WATERPIG_AUTOSNAP=true rspec spec/features/my_cool_spec.rb
+```
 
-Or set the rspec config waterpig_autosnap? to true in your config.
+Or set `config.waterpig_autosnap?` to true in your RSpec config.
 
-Screenshots will be emitted into tmp/, with a subdirectory named for each spec and a numbered file for each step.
-To change the screenshot destination, set waterpig_
-   
+Screenshots will be emitted into `tmp/`, with a subdirectory named for each
+spec and a numbered file for each step.
+
 Browser Console Logging
 -----------------------
 
-The Waterpig::BrowserConsoleLogger class can execute a remote call to console.history() in your browser to retrieve   
+The Waterpig::BrowserConsoleLogger class can execute a remote call to console.history() in your browser to retrieve
 the contents of the browser console, and log it to file.  This is extremely useful for debugging front-end issues
-during integration specs.  
+during integration specs.
 
-For browser console logging to work, the console.history() method must have already been defined in your browser.  
+For browser console logging to work, the console.history() method must have already been defined in your browser.
 This must be handled separately, see the console history injector in Xing for an example.
 
 To turn on browser console logging:
 
-
 At the command line:
-    LOG_BROWSER_CONSOLE=true rspec spec/features/my_cool_spec.rb
+```
+LOG_BROWSER_CONSOLE=true rspec spec/features/my_cool_spec.rb
+```
 
 In your rspec config
-    RSpec.configure do |config|
-      config.waterpig_log_browser_console = true
-    end
+```ruby
+RSpec.configure do |config|
+  config.waterpig_log_browser_console = true
+end
+```
 
+# Experimental Features
 
-Blocking Spec Cleanup For Browser Requests
-------------------------------------------
+These are features of Waterpig that are being used in real projects, but for
+which the interfaces in Waterpig haven't been designed yet.
+
+## Blocking Spec Cleanup For Browser Requests
 
 Much suffering is caused when rspec and Capybara clean up after a spec while a request is still being
 processed. Typically, the database fixtures are reset by DatabaseCleaner because rspec thinks the example
 is complete, but then something fails in Rails when an expected database record is absent.  This can cause
 mysterious intermittant, timing-related failures in specs.
 
-To fix this, install Waterpig::RackRequestWait as a middleware and configure your end-to-end tests to block 
-on Waterpig::RackRequestWait.wait_for_idle(), as follows:
+To fix this, install `RequestWaitMiddleware` as a middleware and configure your
+end-to-end tests to block on `Waterpig::RequestWaitMiddleware.wait_for_idle()`,
+as follows:
 
 In config/environments/test.rb
-    Rails.application.configure do
-      config.middleware.unshift Waterpig::RackRequestWait
+```
+Rails.application.configure do
+  config.middleware.unshift Waterpig::RequestWaitMiddleware
+end
+```
+
+In your rspec config, wrap your (e.g.) database cleanup command in a call to
+`wait_for_idle()`.  Assuming all your end-to-end tests have the metadata `:type
+=> :feature`, you could:
+
+```ruby
+RSpec.configure do |config|
+
+  config.before(:all, :type => :feature) do
+    Waterpig::RequestWaitMiddleware.wait_for_idle do
+      DatabaseCleaner.clean(:truncation)
     end
+  end
+end
+```
 
-In your rspec config, wrap your database cleanup command in a call to wait_for_idle().  Assuming all your
-end-to-end tests have the metadata :type => :feature, you could:
 
-    RSpec.configure do |config|
-
-      config.before(:all, :type => :feature) do
-        Waterpig::RackRequestWait.wait_for_idle do 
-          DatabaseCleaner.clean(:truncation)
-        end
-      end
-   
-
-Rebuilding the Test Database from a Template
---------------------------------------------
+## Rebuilding the Test Database from a Template
 
 If you are using DatabaseCleaner or other truncation method, cleaning your database between tests can be slow,
 particularly if your database has a lot of setup in seeds.rb.  Waterpig's solution is to use a second, test
@@ -96,23 +115,80 @@ template feature to re-initialize the test database from that template.
 
 In your database.yml, configure the test database with a template: setting, and  an additional template DB.
 
-    test:
-      adapter: postgresql
-      database: my_app_test
-      template: my_app_test_template
+```yaml
+test:
+  adapter: postgresql
+  database: my_app_test
+  template: my_app_test_template
 
-    test_template:
-      adapter: postgresql
-      database: my_app_test_template
+test_template:
+  adapter: postgresql
+  database: my_app_test_template
+```
 
-Create the template database at the command line the same as any other Rails DB, treat "test_template" as a 
-Rails environment for this purpose:
-
-    > RAILS_ENV=test_template bundle exec rake db:create
+That's it! Waterpig will create the template database if it doesn't exist.
 
 NOTE:  the test template maintainer code can detect new migrations, but cannot detect changes to db/seeds.rb. If
-you have changed your seeds file without adding a new migration, your test template will not have the new seeds 
+you have changed your seeds file without adding a new migration, your test template will not have the new seeds
 until you drop and rebuild it.  You can do that with:
 
+```
+> RAILS_ENV=test_template bundle exec rake db:drop
+```
 
-    > RAILS_ENV=test_template bundle exec rake db:drop db:create
+Or, you can add a this to `lib/tasks/databases.rb` (possibly a new file) in
+your Rails project:
+
+```ruby
+namespace :db do
+  task :seed do
+    ActiveRecord::DatabaseTasks.drop_current(:test_template)
+    ActiveRecord::DatabaseTasks.create_current(:test_template)
+  end
+end
+```
+
+which will automate the process whenever you db:seed development.
+
+
+## How to Use
+
+The intention is to have Waterpig set this all up when requested. There are
+some challenges around when to do which thing however, and we wanted to roll
+this out.
+
+For the moment, you can do this:
+
+```ruby
+require 'waterpig/template-refresh'
+require 'waterpig/request-wait-middleware'
+
+RSpec.configure do |config|
+  config.waterpig_skip_cleaning_types = [:feature]
+
+  config.prepend_before(:suite) do
+    Waterpig::TemplateRefresh.load_if_pending!(:test_template)
+    Waterpig::TemplateRefresh.commandeer_database(:test)
+  end
+
+  rebuild_types = ["feature"]
+
+  last_type = nil
+
+  config.after(:all) do
+    last_type = self.class.metadata[:type].to_s
+  end
+
+  config.before(:all, :type => proc{|type| rebuild_types.include?(type.to_s)}) do
+    Waterpig::RequestWaitMiddleware.wait_for_idle do
+      Waterpig::TemplateRefresh.refresh_database(:test)
+    end
+  end
+
+  config.before(:all, :type => proc{|type| !rebuild_types.include?(type.to_s)}) do
+    if rebuild_types.include?(last_type)
+      Waterpig::TemplateRefresh.refresh_database(:test)
+    end
+  end
+end
+```

--- a/lib/waterpig/request-wait-middleware.rb
+++ b/lib/waterpig/request-wait-middleware.rb
@@ -1,0 +1,60 @@
+require 'thread'
+
+module Waterpig
+  class RequestWaitMiddleware
+    @@idle_mutex = Mutex.new
+
+    @@waiting_requests = {}
+    @@block_requests = false
+
+    # This is the only method one would normally call: wrap calls that e.g. drop
+    # the test database in wait_for_idle{ <code> } in order to be sure that
+    # outstanding requests are complete
+    def self.wait_for_idle
+      @@block_requests = true
+
+      @@idle_mutex.synchronize do
+        yield
+      end
+
+      @@block_requests = false
+    end
+
+    def block_requests?
+      @@block_requests
+    end
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      increment_active_requests(env)
+      if block_requests?
+        block_request
+      else
+        @app.call(env)
+      end
+    ensure
+      decrement_active_requests(env)
+    end
+
+    BLOCKED = [503, {}, ["Test is over - server no longer available"]].freeze
+
+    def block_request
+      BLOCKED
+    end
+
+    def increment_active_requests(env)
+      @@idle_mutex.lock unless @@idle_mutex.owned?
+      @@waiting_requests[env.object_id] = true
+    end
+
+    def decrement_active_requests(env)
+      @@waiting_requests.delete(env.object_id)
+      if @@waiting_requests.empty?
+        @@idle_mutex.unlock
+      end
+    end
+  end
+end

--- a/lib/waterpig/request-wait-middleware.rb
+++ b/lib/waterpig/request-wait-middleware.rb
@@ -1,6 +1,16 @@
 require 'thread'
 
 module Waterpig
+
+  # This Rack middleware is designed to resolve common timing problems with
+  # end-to-end tests. Without it, specs will often finish and :after hooks will
+  # get executed while a request is still "in flight". The result can be, for
+  # example, specs failing because the database has been wiped before a request
+  # truly finishes.
+  #
+  # This middleware counts requests and allows other processes (e.g. testing
+  # processes) to block via RequestWaitMiddle.wait_for_idle() so that they do
+  # not proceed until all requests have completed.
   class RequestWaitMiddleware
     @@idle_mutex = Mutex.new
 

--- a/lib/waterpig/template-refresh.rb
+++ b/lib/waterpig/template-refresh.rb
@@ -1,5 +1,14 @@
 module Waterpig
-  # This code is all essentially cribbed from ActiveRecord here and there
+
+
+  # Tool to handle migrations and rebuilds on a test template database.  For
+  # explanation of what the test templated DB is and how it's used, see the
+  # README.
+  #
+  # This should auto detect any needed migrations in that database. However, it
+  # does not detect changes to db/seeds.rb, so if you have changed seeds
+  # without adding a DB migration, you will need to drop and rebuild the
+  # test_template.
   module TemplateRefresh
     extend self
 

--- a/lib/waterpig/template-refresh.rb
+++ b/lib/waterpig/template-refresh.rb
@@ -1,0 +1,110 @@
+module Waterpig
+  # This code is all essentially cribbed from ActiveRecord here and there
+  module TemplateRefresh
+    extend self
+
+    def load_config
+      ActiveRecord::Base.configurations       = ActiveRecord::Tasks::DatabaseTasks.database_configuration || {}
+      ActiveRecord::Migrator.migrations_paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
+    end
+
+    def purge_env(env)
+      ActiveRecord::Tasks::DatabaseTasks.purge(config_for(env))
+    end
+
+    def with_temporary_connection(env)
+      begin
+        should_reconnect = ActiveRecord::Base.connection_pool.active_connection?
+
+        yield
+      ensure
+        if should_reconnect
+          ActiveRecord::Base.establish_connection(config_for(ActiveRecord::Tasks::DatabaseTasks.env))
+        end
+      end
+    end
+
+    #Assumes schema_format == ruby
+    def load_schema(env)
+      ActiveRecord::Schema.verbose = false
+      ActiveRecord::Tasks::DatabaseTasks.load_schema_for config_for(env), :ruby, ENV['SCHEMA']
+    end
+
+    def load_seed
+      ActiveRecord::Tasks::DatabaseTasks.load_seed
+      # load('spec/test_seeds.rb')
+    end
+
+    Base = ActiveRecord::Base
+
+    def config_for(env)
+      ActiveRecord::Base.configurations.fetch(env.to_s)
+    end
+
+    def connection_for(env)
+      ActiveRecord::Base.establish_connection(env).connection
+    end
+
+    def if_needs_migration(env)
+      if ActiveRecord::Migrator.needs_migration?(connection_for(env))
+        begin
+          current_config = Base.connection_config
+          Base.clear_all_connections!
+
+          yield
+
+        ensure
+          Base.establish_connection(current_config)
+
+          ActiveRecord::Migration.check_pending!
+        end
+      end
+    end
+
+    def ensure_created(env)
+      ActiveRecord::Base.establish_connection(env).connection
+    rescue ActiveRecord::NoDatabaseError
+      ActiveRecord::Tasks::DatabaseTasks.create(config_for(env))
+    end
+
+
+    def load_if_pending!(env)
+      ensure_created(env)
+      if_needs_migration(env) do
+        puts "Refreshing unmigrated test env: #{env}"
+        purge_env(env)
+        with_temporary_connection(env) do
+          load_schema(env)
+          load_seed
+        end
+      end
+    end
+
+    def commandeer_database(env)
+      config = config_for(env)
+      connection_for(env).select_all(
+        "select pid, pg_terminate_backend(pid) " +
+        "from pg_stat_activity where datname='#{config['database']}' AND state='idle';")
+    end
+
+    def refresh_database(env)
+      Rails.logger.fatal("Resetting test DB...")
+      config = config_for(env)
+
+      tasks = ActiveRecord::Tasks::PostgreSQLDatabaseTasks.new(config)
+
+      start = Time.now
+      Rails.logger.fatal("Dropping")
+      begin
+        tasks.drop
+      end
+      Rails.logger.fatal("Creating")
+      begin
+        tasks.create
+      end
+      message = "Test database recopied in #{Time.now - start}s"
+      #puts message
+      Rails.logger.fatal(message)
+    end
+  end
+end


### PR DESCRIPTION
RequestWaitMiddleware is clearly a WP concern
TemplateRefresh is tightly coupled to it

Potential future work:
  adding template refresh to the db cleaning options?
  making request wait a before/after for certain types?
